### PR TITLE
A few optimizations

### DIFF
--- a/include/correction.h
+++ b/include/correction.h
@@ -96,7 +96,6 @@ class Binning {
     std::vector<std::tuple<double, Content>> bins_;
     size_t variableIdx_;
     _FlowBehavior flow_;
-    std::unique_ptr<const Content> default_value_;
 };
 
 class MultiBinning {
@@ -110,7 +109,6 @@ class MultiBinning {
     std::vector<std::tuple<size_t, size_t, std::vector<double>>> axes_;
     std::vector<Content> content_;
     _FlowBehavior flow_;
-    std::unique_ptr<const Content> default_value_;
 };
 
 class Category {

--- a/include/correction.h
+++ b/include/correction.h
@@ -49,7 +49,6 @@ class Formula {
   private:
     std::string expression_;
     ParserType type_;
-    std::vector<size_t> variableIdx_;
 
     static std::map<ParserType, peg::parser> parsers_;
     static std::mutex parsers_mutex_; // could be one per parser, but this is good enough
@@ -80,9 +79,9 @@ class Formula {
       // TODO: try std::unique_ptr<const Ast> child1, child2 or std::array
     };
     std::unique_ptr<const Ast> ast_;
-    void build_ast(const std::vector<double>& params);
-    const Ast translate_ast(const peg::Ast& ast, const std::vector<double>& params) const;
-    double eval_ast(const Ast& ast, const std::vector<double>& variables) const;
+    void build_ast(const std::vector<double>& params, const std::vector<size_t>& variableIdx);
+    const Ast translate_ast(const peg::Ast& ast, const std::vector<double>& params, const std::vector<size_t>& variableIdx) const;
+    double eval_ast(const Ast& ast, const std::vector<Variable::Type>& variables) const;
 };
 
 // common internal for Binning and MultiBinning

--- a/src/demo.cc
+++ b/src/demo.cc
@@ -9,6 +9,7 @@ int main(int argc, char** argv) {
     printf("sizeof(MultiBinning): %lu\n", sizeof(MultiBinning));
     printf("sizeof(Category): %lu\n", sizeof(Category));
     printf("sizeof(Formula): %lu\n", sizeof(Formula));
+    printf("sizeof(Content): %lu\n", sizeof(Content));
   }
   else if ( argc == 2 ) {
     auto cset = CorrectionSet::from_file(std::string(argv[1]));
@@ -24,7 +25,7 @@ int main(int argc, char** argv) {
     out = deepcsv->evaluate({"central", 0, 1.2, 35., 0.01});
     printf("DeepCSV_2016LegacySF('central', 0, 1.2, 35., 0.5) = %f\n", out);
     double stuff {0.};
-    int n { 1000000 };
+    size_t n { 1000000 };
     for(size_t i=0; i<n; ++i) {
       stuff += deepcsv->evaluate({"central", 0, 1.2, 35., i / (double) n});
     }


### PR DESCRIPTION
One due to an expensive allocation (seen in profiler)
The other due to an unproven suspicion that small `sizeof(Content)` is better (more nodes can stay in cache)